### PR TITLE
LayerManager: abort fetch is not possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "url-loader": "^0.5.7",
     "vega": "2.5.2",
     "webpack": "^1.13.3",
-    "webpack-dev-middleware": "^1.8.4"
+    "webpack-dev-middleware": "^1.8.4",
+    "whatwg-fetch": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^3.9.1",

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -28,3 +28,23 @@ export function concatenation(string, params) {
   });
   return str;
 }
+
+export function makePromiseCancelable(promise) {
+  let hasCanceled_ = false;
+
+  const wrappedPromise = new Promise((resolve, reject) => {
+    promise.then((val) => {
+      hasCanceled_ ? reject({ isCanceled: true }) : resolve(val);
+    });
+    promise.catch((error) => {
+      hasCanceled_ ? reject({ isCanceled: true }) : reject(error);
+    });
+  });
+
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      hasCanceled_ = true;
+    }
+  };
+}


### PR DESCRIPTION
Eventually, we CAN'T abort fetch requests (https://github.com/whatwg/fetch/issues/447). 

Solution:
We are going to wrap the promise in another promise to set it as cancelable. This is not the best solution because we are still waiting for the response of the call. (https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html)

Should we add a library that solves this? I think we should