### PR TITLE
Layers premature callback execution

### DIFF
--- a/src/utils/layers/LayerManager.js
+++ b/src/utils/layers/LayerManager.js
@@ -20,6 +20,8 @@ export default class LayerManager {
     this._map = map;
     this._mapLayers = {};
     this._mapRequests = {};
+    this.layersLoading = {};
+    this.rejectLayersLoading = false;
     this._onLayerAddedSuccess = options.onLayerAddedSuccess;
     this._onLayerAddedError = options.onLayerAddedError;
   }
@@ -34,7 +36,15 @@ export default class LayerManager {
       cartodb: this._addCartoLayer
     }[layer.provider];
 
-    return method && method.call(this, layer, opts);
+    method && method.call(this, layer, opts);
+    this._execCallback()
+      .then(() =>{
+        this._onLayerAddedSuccess && this._onLayerAddedSuccess();
+      })
+      .catch(() => {
+        this.rejectLayersLoading = false;
+        this._onLayerAddedError && this._onLayerAddedError();
+      });
   }
 
   removeLayer(layerId) {
@@ -56,12 +66,29 @@ export default class LayerManager {
   /*
     Private methods
   */
+  _execCallback() {
+    let timeout;
+    const ready = new Promise((resolve, reject) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => reject(), 20000); // if it takes +20s something's wrong: reject the promise
+
+      const loop = () => {
+        if(!Object.keys(this.layersLoading).length) return resolve();
+        if(this.rejectLayersLoading) return reject();
+        setTimeout(loop);
+      };
+      setTimeout(loop);
+    });
+    return ready;
+  }
+
   _addLeafletLayer(layerSpec, { zIndex }) {
     const layerData = layerSpec.layerConfig;
 
     let layer;
 
     layerData.id = layerSpec.id;
+    this.layersLoading[layerData.id] = true;
 
     // Transforming data layer
     // TODO: improve this
@@ -81,6 +108,7 @@ export default class LayerManager {
         layer = new L.tileLayer(layerData.url, layerData.body); // eslint-disable-line
         break;
       default:
+        delete this.layersLoading[layerData.id];
         throw new Error('"type" specified in layer spec doesn`t exist');
     }
 
@@ -88,7 +116,7 @@ export default class LayerManager {
       const eventName = (layerData.type === 'wms' ||
       layerData.type === 'tileLayer') ? 'tileload' : 'load';
       layer.on(eventName, () => {
-        this._onLayerAddedSuccess && this._onLayerAddedSuccess(layer);
+        delete this.layersLoading[layerData.id];
       });
       if (zIndex) {
         layer.setZIndex(zIndex);
@@ -101,6 +129,7 @@ export default class LayerManager {
     const layer = layerSpec.layerConfig;
     layer.id = layerSpec.id;
 
+    this.layersLoading[layer.id] = true;
     // Transforming layer
     // TODO: change this please @ra
     const bodyStringified = JSON.stringify(layer.body || {})
@@ -115,8 +144,9 @@ export default class LayerManager {
         layerConfig.style = eval(`(${layerConfig.style})`); // eslint-disable-line
       }
       const newLayer = L.esri[layer.type](layerConfig);
+
       newLayer.on('load', () => {
-        this._onLayerAddedSuccess && this._onLayerAddedSuccess(layer);
+        delete this.layersLoading[layer.id];
         const layerElement = this._map.getPane('tilePane').lastChild;
         if (zIndex) {
           layerElement.style.zIndex = zIndex;
@@ -126,6 +156,8 @@ export default class LayerManager {
       newLayer.addTo(this._map);
       this._mapLayers[layer.id] = newLayer;
     } else {
+      delete this.layersLoading[layer.id];
+      this.rejectLayersLoading = true;
       throw new Error('"type" specified in layer spec doesn`t exist');
     }
   }
@@ -141,6 +173,7 @@ export default class LayerManager {
       if (this._mapRequests[layer.category].readyState !== 4) {
         this._mapRequests[layer.category].abort();
         delete this._mapRequests[layer.category];
+        delete this.layersLoading[layer.id];
       }
     }
 
@@ -148,6 +181,7 @@ export default class LayerManager {
       case 'mask' : {
         const body = getWaterSql(layer, options);
 
+        this.layersLoading[layer.id] = true;
         const xmlhttp = new XMLHttpRequest();
         xmlhttp.open('POST', `https://${layer.account}.carto.com/api/v1/map`);
         xmlhttp.setRequestHeader('Content-Type', 'application/json');
@@ -163,13 +197,15 @@ export default class LayerManager {
               this._mapLayers[layer.id] = L.tileLayer(tileUrl).addTo(this._map).setZIndex(999);
 
               this._mapLayers[layer.id].on('load', () => {
-                this._onLayerAddedSuccess && this._onLayerAddedSuccess(layer);
+                delete this.layersLoading[layer.id];
               });
               this._mapLayers[layer.id].on('tileerror', () => {
-                this._onLayerAddedError && this._onLayerAddedError(layer);
+                delete this.layersLoading[layer.id];
+                this.rejectLayersLoading = true;
               });
             } else {
-              this._onLayerAddedError && this._onLayerAddedError(layer);
+              delete this.layersLoading[layer.id];
+              this.rejectLayersLoading = true;
             }
           }
         };
@@ -182,6 +218,7 @@ export default class LayerManager {
       case 'water': {
         const body = getWaterSql(layer, options);
 
+        this.layersLoading[layer.id] = true;
         const xmlhttp = new XMLHttpRequest();
         xmlhttp.open('POST', `https://${layer.account}.carto.com/api/v1/map`);
         xmlhttp.setRequestHeader('Content-Type', 'application/json');
@@ -191,19 +228,21 @@ export default class LayerManager {
           if (xmlhttp.readyState === 4) {
             if (xmlhttp.status === 200) {
               const data = JSON.parse(xmlhttp.responseText);
-              // we can switch off the layer while it is loading
+
               const tileUrl = `https://${layer.account}.carto.com/api/v1/map/${data.layergroupid}/{z}/{x}/{y}.png`;
 
               this._mapLayers[layer.id] = L.tileLayer(tileUrl).addTo(this._map).setZIndex(998);
 
               this._mapLayers[layer.id].on('load', () => {
-                this._onLayerAddedSuccess && this._onLayerAddedSuccess(layer);
+                delete this.layersLoading[layer.id];
               });
               this._mapLayers[layer.id].on('tileerror', () => {
-                this._onLayerAddedError && this._onLayerAddedError(layer);
+                delete this.layersLoading[layer.id];
+                this.rejectLayersLoading = true;
               });
             } else {
-              this._onLayerAddedError && this._onLayerAddedError(layer);
+              delete this.layersLoading[layer.id];
+              this.rejectLayersLoading = true;
             }
           }
         };
@@ -216,6 +255,7 @@ export default class LayerManager {
       case 'food': {
         const body = getFoodSql(layer, options);
 
+        this.layersLoading[layer.id] = true;
         const xmlhttp = new XMLHttpRequest();
         xmlhttp.open('GET', body.url);
         xmlhttp.send();
@@ -229,9 +269,10 @@ export default class LayerManager {
                 geojson, layer
               ).addTo(this._map);
 
-              this._onLayerAddedSuccess && this._onLayerAddedSuccess(layer);
+              delete this.layersLoading[layer.id];
             } else {
-              this._onLayerAddedError && this._onLayerAddedError(layer);
+              delete this.layersLoading[layer.id];
+              this.rejectLayersLoading = true;
             }
           }
         };

--- a/src/utils/layers/LayerManager.js
+++ b/src/utils/layers/LayerManager.js
@@ -42,6 +42,7 @@ export default class LayerManager {
         this._onLayerAddedSuccess && this._onLayerAddedSuccess();
       })
       .catch(() => {
+        this.layersLoading = {};
         this.rejectLayersLoading = false;
         this._onLayerAddedError && this._onLayerAddedError();
       });
@@ -61,6 +62,7 @@ export default class LayerManager {
         delete this._mapLayers[id];
       }
     });
+    this.layersLoading = {};
   }
 
   /*
@@ -156,7 +158,6 @@ export default class LayerManager {
       newLayer.addTo(this._map);
       this._mapLayers[layer.id] = newLayer;
     } else {
-      delete this.layersLoading[layer.id];
       this.rejectLayersLoading = true;
       throw new Error('"type" specified in layer spec doesn`t exist');
     }
@@ -200,11 +201,9 @@ export default class LayerManager {
                 delete this.layersLoading[layer.id];
               });
               this._mapLayers[layer.id].on('tileerror', () => {
-                delete this.layersLoading[layer.id];
                 this.rejectLayersLoading = true;
               });
             } else {
-              delete this.layersLoading[layer.id];
               this.rejectLayersLoading = true;
             }
           }
@@ -237,11 +236,9 @@ export default class LayerManager {
                 delete this.layersLoading[layer.id];
               });
               this._mapLayers[layer.id].on('tileerror', () => {
-                delete this.layersLoading[layer.id];
                 this.rejectLayersLoading = true;
               });
             } else {
-              delete this.layersLoading[layer.id];
               this.rejectLayersLoading = true;
             }
           }
@@ -271,7 +268,6 @@ export default class LayerManager {
 
               delete this.layersLoading[layer.id];
             } else {
-              delete this.layersLoading[layer.id];
               this.rejectLayersLoading = true;
             }
           }

--- a/src/utils/layers/LayerManager.js
+++ b/src/utils/layers/LayerManager.js
@@ -7,7 +7,6 @@ import esri from 'esri-leaflet';
 // Layers
 import BubbleClusterLayer from 'utils/layers/markers/BubbleClusterLayer';
 // Functions
-import { makePromiseCancelable } from 'utils/utils';
 import { getWaterSql, getFoodSql } from 'utils/filters/filters';
 
 // adding support for esri
@@ -38,7 +37,7 @@ export default class LayerManager {
 
     method && method.call(this, layer, opts);
     this._execCallback()
-      .then(() =>{
+      .then(() => {
         this._onLayerAddedSuccess && this._onLayerAddedSuccess();
       })
       .catch(() => {
@@ -69,15 +68,14 @@ export default class LayerManager {
     Private methods
   */
   _execCallback() {
-    const ready = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const loop = () => {
-        if(!Object.keys(this._layersLoading).length) return resolve();
-        if(this._rejectLayersLoading) return reject();
+        if (!Object.keys(this._layersLoading).length) return resolve();
+        if (this._rejectLayersLoading) return reject();
         setTimeout(loop);
       };
       setTimeout(loop);
     });
-    return ready;
   }
 
   _addLeafletLayer(layerSpec, { zIndex }) {

--- a/src/utils/layers/LayerManager.js
+++ b/src/utils/layers/LayerManager.js
@@ -69,11 +69,7 @@ export default class LayerManager {
     Private methods
   */
   _execCallback() {
-    let timeout;
     const ready = new Promise((resolve, reject) => {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => reject(), 20000); // if it takes +20s something's wrong: reject the promise
-
       const loop = () => {
         if(!Object.keys(this._layersLoading).length) return resolve();
         if(this._rejectLayersLoading) return reject();


### PR DESCRIPTION
This PR add the following:
- Fixes issue where loaded callback was being execute on first layer load instead of in last.

**How?**
Maintains a dictionary of the layers being loaded, when a layer loads it gets removed from the dictionary, and actively waits until the dictionary is empty.