### PR TITLE
Add the filters to the sticky component

### DIFF
--- a/src/components/filters/StickyFilters.jsx
+++ b/src/components/filters/StickyFilters.jsx
@@ -1,11 +1,143 @@
-
 import React from 'react';
+import { Link } from 'react-router';
+import { SegmentedUi, Icon, CustomSelect } from 'aqueduct-components';
+import { scopeOptions, cropOptions, waterOptions, foodOptions, yearOptions, changeFromBaselineOptions } from 'constants/filters';
+import ShareModal from 'containers/modal/ShareModal';
+import CountrySelect from 'containers/countries/CountrySelect';
 
 class StickyFilters extends React.Component {
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      countryToCompare: null
+    };
+  }
+
+  updateFilters(value, field) {
+    const newFilter = {
+      [field]: value
+    };
+    this.props.setFilters(newFilter);
+  }
+
+  toggleShareModal() {
+    this.props.toggleModal(true, {
+      children: ShareModal
+    });
+  }
+
   render() {
-    return (<div className="c-sticky-filters" />);
+    return (
+      <div className="c-sticky-filters">
+        {this.props.withScope &&
+          <div className="filters-lead">
+            <div className="row expanded collapse">
+              <div className="small-12 column">
+                <SegmentedUi
+                  className="-tabs"
+                  items={scopeOptions}
+                  selected={this.props.filters.scope}
+                  onChange={selected => this.updateFilters(selected.value, 'scope')}
+                />
+                <button type="button" className="-white -with-icon btn-share" onClick={this.toggleShareModal}>
+                  <Icon className="-medium" name="icon-share" />
+                  Share
+                </button>
+              </div>
+            </div>
+          </div>
+        }
+        {this.props.withScope && this.props.filters.scope === 'country' &&
+          <div className="country-filters">
+            <div>
+              <span className="title">Select a country</span>
+              <CountrySelect
+                className="-mini"
+                value={this.props.filters.country !== 'null' ? this.props.filters.country : null}
+                onValueChange={selected => this.updateFilters(selected && selected.value, 'country')}
+              />
+            </div>
+            <div>
+              <span className="title">Compare With</span>
+              <CountrySelect
+                className={`-mini ${this.props.filters.country ? '' : '-disabled'}`}
+                placeholder="Country name..."
+                value={this.state.countryToCompare}
+                onValueChange={selected => this.setState({ countryToCompare: selected.value })}
+              />
+            </div>
+            <div>
+              <Link
+                className={`c-btn -filters ${this.state.countryToCompare ? '' : '-disabled'}`}
+                to={`/compare?countries=${this.props.filters.country},${this.state.countryToCompare}`}
+              >
+                Compare
+              </Link>
+            </div>
+          </div>
+        }
+        <div className="global-filters">
+          <div>
+            <span className="title">Crops</span>
+            <CustomSelect
+              search
+              className="-mini"
+              options={cropOptions}
+              value={this.props.filters.crop}
+              onValueChange={selected => selected && this.updateFilters(selected.value, 'crop')}
+            />
+          </div>
+          <div>
+            <span className="title">Water Risk</span>
+            <CustomSelect
+              className="-mini"
+              options={waterOptions}
+              value={this.props.filters.water}
+              onValueChange={selected => selected && this.updateFilters(selected.value, 'water')}
+            />
+          </div>
+          <div>
+            <span className="title">Country data</span>
+            <CustomSelect
+              className={`-mini ${this.props.filters.scope === 'country' ? '-disabled -no-search' : '-no-search'}`}
+              options={foodOptions}
+              value={this.props.filters.food}
+              onValueChange={selected => selected && this.updateFilters(selected.value, 'food')}
+            />
+          </div>
+          <div>
+            <span className="title">Timeframe</span>
+            <CustomSelect
+              className="-mini"
+              options={yearOptions}
+              value={yearOptions.find(i => i.value === this.props.filters.year).value}
+              onValueChange={(selected) => {
+                selected && selected.value === 'baseline' && this.updateFilters(false, 'changeFromBaseline');
+                selected && this.updateFilters(selected.value, 'year');
+              }}
+            />
+            {this.props.filters.year !== 'baseline' &&
+              <CustomSelect
+                className="-mini"
+                options={changeFromBaselineOptions.map(option => Object.assign({}, option, { value: option.value.toString() }))}
+                value={this.props.filters.changeFromBaseline.toString()}
+                onValueChange={selected => this.updateFilters(selected.value, 'changeFromBaseline')}
+              />
+            }
+          </div>
+        </div>
+      </div>
+    );
   }
 }
+
+StickyFilters.propTypes = {
+  setFilters: React.PropTypes.func,
+  filters: React.PropTypes.object,
+  withScope: React.PropTypes.bool,
+  toggleModal: React.PropTypes.func
+};
 
 export default StickyFilters;

--- a/src/components/pages/Map/Content/Desktop.jsx
+++ b/src/components/pages/Map/Content/Desktop.jsx
@@ -86,8 +86,15 @@ export default class MapPageDesktop extends React.Component {
             onStick={(isSticky) => { this.onSticky(isSticky); }}
             ScrollElem=".l-sidebar-content"
           >
-            {this.state.showStickyFilters &&
-              <StickyFilters />}
+            {
+              this.state.showStickyFilters &&
+                <StickyFilters
+                  filters={this.props.filters}
+                  setFilters={this.props.setFilters}
+                  toggleModal={this.props.toggleModal}
+                  withScope
+                />
+            }
           </Sticky>
           {/* Widget List */}
           <div className="l-sidebar-content">

--- a/src/styles/components/_filters.scss
+++ b/src/styles/components/_filters.scss
@@ -118,6 +118,27 @@
   }
 }
 
+.c-custom-select {
+  &.-mini {
+    display: inline-block;
+    width: auto;
+    padding-right: ($space-1 * 3);
+    border-bottom: 0;
+
+    &::after {
+      border-bottom-color: palette(gray, 'light');
+    }
+
+    .custom-select-text {
+      max-height: 22px;
+      min-height: 22px;
+      line-height: 22px;
+      font-size: $font-size-default;
+      color: palette(gray, 'dark');
+    }
+  }
+}
+
 /* Mobile */
 .c-mobile-filters {
   &.-compare {

--- a/src/styles/components/_sticky-filters.scss
+++ b/src/styles/components/_sticky-filters.scss
@@ -1,7 +1,42 @@
-
 .c-sticky-filters {
   display: inline-block;
   width: 100%;
-  background-color: palette(blue);
   height: 100%;
+  background-color: palette(sand);
+  box-shadow: 0 1px 0 0 #dbdfe5;
+
+  .filters-lead {
+    background-color: palette(blue);
+  }
+
+  .global-filters,
+  .country-filters {
+    display: flex;
+    padding: $space-1 ($space-1 * 3);
+
+    > div {
+      flex-grow: 1;
+      margin-right: ($space-1 * 3);
+      &:last-of-type { margin-right: 0; }
+
+      .c-custom-select + .c-custom-select {
+        margin-left: ($space-1 * 2);
+      }
+
+      .c-btn {
+        color: palette(gray);
+        border-color: palette(gray);
+      }
+    }
+
+    .title {
+      display: block;
+      height: 18px;
+      opacity: .5;
+      color: palette(gray, 'dark');
+      line-height: 22px;
+      text-transform: uppercase;
+      letter-spacing: .9px;
+    }
+  }
 }

--- a/src/styles/components/_sticky.scss
+++ b/src/styles/components/_sticky.scss
@@ -12,7 +12,6 @@
     &.-sticked {
       left: 0;
       width: 100%;
-      height: 40px;
     }
   }
 }


### PR DESCRIPTION
This PR adds the filters to the sticky component.

<img width="812" alt="Screenshot of the sticky filters" src="https://cloud.githubusercontent.com/assets/6073968/23606872/81ccb782-025a-11e7-8177-17746203e901.png">

Because there isn't any design of the country tab, I just placed them before the others, using the same styles.

<img width="851" alt="Screenshot of the sticky filters with the country tab active" src="https://cloud.githubusercontent.com/assets/6073968/23606917/c5aeaae6-025a-11e7-8772-a54bd8812d1c.png">

[Pivotal task](https://www.pivotaltracker.com/story/show/140417483)